### PR TITLE
Feature/#16 swagger 설정을 위한 securiy 설정 변경

### DIFF
--- a/src/main/java/com/app/univchat/config/SecurityConfig.java
+++ b/src/main/java/com/app/univchat/config/SecurityConfig.java
@@ -77,7 +77,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
                 .authorizeRequests()
                 .antMatchers("/swagger-resources/**").permitAll()
-                .antMatchers("/swagger-ui.html/**").permitAll()
+                .antMatchers("/swagger-ui/**").permitAll()
                 .antMatchers("/webjars/**").permitAll()
                 .antMatchers("/v3/api-docs").permitAll()
                 .antMatchers("/hello/**").permitAll()


### PR DESCRIPTION
springfox 3.0.0 버전부터는 swagger url이 /swagger-ui/index.html로 변경되었음을 확인함에 따라 다시 원 상태로 secuiry 설정을 변경합니다.