### PR TITLE
Feature/#68 채팅 메시지 전송 시 발생하는 에러에 대한 핸들링 코드 작성

### DIFF
--- a/src/main/java/com/app/univchat/base/BaseResponseStatus.java
+++ b/src/main/java/com/app/univchat/base/BaseResponseStatus.java
@@ -77,7 +77,7 @@ public enum  BaseResponseStatus {
     JWT_HIJACK_ACCESS_TOKEN("6007", "만료된(탈취된) 서명입니다.", 400),
     JWT_INVALID_REFRESH_TOKEN("6008", "유효하지 않은 리프레시 토큰입니다.", 400),
     JWT_INVALID_USER_JWT("6008", "입력 RT와 사용자 RT가 일치하지 않습니다", 400),
-
+    JWT_AND_NICKNAME_DONT_MATCH("6009", "JWT와 닉네임이 일치하지 않습니다.", 400),
     ;
 
     private final String code;

--- a/src/main/java/com/app/univchat/config/WebSocketConfig.java
+++ b/src/main/java/com/app/univchat/config/WebSocketConfig.java
@@ -1,7 +1,7 @@
 package com.app.univchat.config;
 
 import com.app.univchat.chat.ChatExceptionHandler;
-import com.app.univchat.chat.ChatJwtInterceptor;
+import com.app.univchat.chat.ChatSendInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
@@ -13,7 +13,7 @@ import org.springframework.web.socket.config.annotation.*;
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-    private final ChatJwtInterceptor chatInterceptor;
+    private final ChatSendInterceptor chatInterceptor;
     private final ChatExceptionHandler chatExceptionHandler;
 
     // 메시지 송수신을 위한 url prefix 설정 및 메시지 브로커 설정

--- a/src/main/java/com/app/univchat/jwt/JwtProvider.java
+++ b/src/main/java/com/app/univchat/jwt/JwtProvider.java
@@ -104,16 +104,19 @@ public class JwtProvider {
      */
     public Authentication getAuthentication(String token){
 //        Claims claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();  // 기존 claim 생성 code
-        String username = Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody().getSubject();
+        String email = getEmail(token);
 
         // user 객체 생성해 Authentication 객체 반환
-        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
 
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
+    public String getEmail(String token) {
+        String username = Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody().getSubject();
 
-
+        return username;
+    }
 
 
 

--- a/src/main/java/com/app/univchat/security/filter/LoginFilter.java
+++ b/src/main/java/com/app/univchat/security/filter/LoginFilter.java
@@ -90,11 +90,9 @@ public class LoginFilter extends AbstractAuthenticationProcessingFilter {
         //토큰 발급
         JwtDto jwtDto = jwtProvider.generateToken(member.getEmail());
 
-        //TODO: redis에 refresh 토큰 저장
         redisService.saveToken(String.valueOf(member.getEmail()),jwtDto.getRefreshToken(), refreshTime);
 
         //response Header 설정
-        //TODO: accessToken 응답 헤더에? 쿠키에? -> 프론트와 논의
         response.setHeader("Authorization", jwtDto.getAccessToken());
 
         response.setContentType("application/json");

--- a/src/main/java/com/app/univchat/service/MemberService.java
+++ b/src/main/java/com/app/univchat/service/MemberService.java
@@ -96,7 +96,7 @@ public class MemberService {
     /**
      * nickname을 통한 member 조회
      */
-    protected Optional<Member> getMember(String nickname) throws IOException{
+    public Optional<Member> getMember(String nickname){
 
         return memberRepository.findByNickname(nickname);
     }

--- a/src/main/resources/static/liveChat.js
+++ b/src/main/resources/static/liveChat.js
@@ -37,7 +37,6 @@ const enterLiveChattingRoom = () => {
                 })
                 .catch(err => console.error(err));
 
-            //TODO: 라이브 채팅 api 작성 후 경로 변경
             // 최근 채팅 내역을 불러 오는 부분
             const page = 0;
             fetch(`http://localhost:8080/live/chat/${page}`)


### PR DESCRIPTION
**구현 목록**
- 닉네임 member DB에 있는지 확인
  - 없을 시 "2004 존재하지 않는 닉네임입니다." 반환
- 닉네임으로 조회한 member 객체와 jwt의 email 동일한지 확인
  - 일치하지 않을 경우 6009 JWT와 닉네임이 일치하지 않습니다." 반환

</br>

--- 
**추가 참고 사항**
- 에러 발생 시 stomp error 커멘드 메시지 반환 후 세션 연결 종료
- 에러는 모두 `BaseException` 사용
- **닉네임 및 jwt 확인 로직** -  `ChannelInterceptor` 구현체 활용
  - `ChannelInterceptor`: web socket에서 메시지 전송 시 가로채서 로직 실행
  - 클래스명 변경: `ChatJwtInterceptor` -> `ChatSendInterceptor`
  - jwt 검사 로직 뒤, 닉네임 확인 로직 추가
- **web socket에서 `BaseException` 에러 핸들링 코드** -  `StompSubProtocolErrorHandler` 구현체 활용
  - websocket 환경에서 발생한 `BaseException` 처리 로직 추가

</br>