### PR TITLE
Feature/#69 1:1 채팅 구현

### DIFF
--- a/src/main/java/com/app/univchat/config/SecurityConfig.java
+++ b/src/main/java/com/app/univchat/config/SecurityConfig.java
@@ -92,10 +92,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 //.antMatchers("/app.js").permitAll()
                 //.antMatchers("/main.css").permitAll()
 
-                .antMatchers("/chattingList.html", "/chattingListStyle.css", "/dormChat.html", "/dormChat.js", "/dormChatStyle.css", "/liveChat.js", "/liveChat.html",  "/loveChat.js", "/loveChat.html").permitAll()
+                .antMatchers("/chattingList.html", "/chattingListStyle.css", "/dormChat.html", "/dormChat.js", "/dormChatStyle.css", "/liveChat.js", "/liveChat.html",  "/loveChat.js", "/loveChat.html", "/otoChat.js", "/otoChat.html").permitAll()
 
                 // 채팅 엔드포인트, 기숙사 채팅 기록 조회 인증 x
                 .antMatchers("/chat/**").permitAll()
+                .antMatchers("/oto/**").permitAll()
                 .antMatchers("/dorm/chat/**", "/live/chat/**", "/love/chat/**").permitAll()
 
                 .anyRequest().authenticated() //위의 api가 아닌 경로는 모두 jwt 토큰 인증을 해야 함

--- a/src/main/java/com/app/univchat/controller/LoveChatController.java
+++ b/src/main/java/com/app/univchat/controller/LoveChatController.java
@@ -43,7 +43,7 @@ public class LoveChatController {
                 .build();
     }
 
-    // 기숙사 채팅 내역을 불러오기 위한 API(http)
+    // 연애상담 채팅 내역을 불러오기 위한 API(http)
     @Tag(name = "chatting")
     @ApiOperation(value = "기숙사 채팅 내역 API", notes = "채팅 내역 최신순으로 10개를 반환하며, 페이지 번호는 0부터 시작합니다.")
     @GetMapping("/chat/{page}")

--- a/src/main/java/com/app/univchat/controller/OTOChatController.java
+++ b/src/main/java/com/app/univchat/controller/OTOChatController.java
@@ -34,7 +34,7 @@ public class OTOChatController {
     @Tag(name = "one_to_one_chat")
     @ApiOperation(value = "1:1 채팅방 개설 API")
     @PostMapping("/room")
-    public BaseResponse<String> createChatRoom(@RequestBody ChatReq.OTOChatRoomReq otoChatRoomReq){
+    public BaseResponse<ChatRes.OTOChatRoomRes> createChatRoom(@RequestBody ChatReq.OTOChatRoomReq otoChatRoomReq){
 
 //        ChatRes.OTOChatRoomRes otoChatRoomRes=otoChatService.createChatRoom(otoChatRoomReq);
         return BaseResponse.ok(BaseResponseStatus.SUCCESS,otoChatService.createChatRoom(otoChatRoomReq));

--- a/src/main/java/com/app/univchat/controller/OTOChatController.java
+++ b/src/main/java/com/app/univchat/controller/OTOChatController.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Controller;
@@ -36,34 +37,33 @@ public class OTOChatController {
     @PostMapping("/room")
     public BaseResponse<ChatRes.OTOChatRoomRes> createChatRoom(@RequestBody ChatReq.OTOChatRoomReq otoChatRoomReq){
 
-//        ChatRes.OTOChatRoomRes otoChatRoomRes=otoChatService.createChatRoom(otoChatRoomReq);
         return BaseResponse.ok(BaseResponseStatus.SUCCESS,otoChatService.createChatRoom(otoChatRoomReq));
 
     }
 
-    // 연애상담 채팅 송신 및 저장을 위한 API(ws)
-//    @MessageMapping("/love")
-//    @SendTo("/sub/love")
-//    public ChatRes.LoveChatRes sendToLoveChattingRoom(ChatReq.LoveChatReq loveChatReq) {
-//
-//        String messageSendingTime = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:SSS").format(new Date());
-//        loveChatService.saveChat(loveChatReq, messageSendingTime);
-//
-//        return new ChatRes.LoveChatRes().builder()
-//                .memberNickname(loveChatReq.getMemberNickname())
-//                .messageContent(loveChatReq.getMessageContent())
-//                .messageSendingTime(messageSendingTime)
-//                .build();
-//    }
+//     1:1 채팅 송신 및 저장을 위한 API(ws)
+    @MessageMapping("/oto")
+    @SendTo("/sub/oto")
+    public ChatRes.OTOChatRes sendToOTOChattingRoom(ChatReq.OTOChatReq otoChatReq) {
 
-    // 1:1 채팅 내역을 불러오기 위한 API(http)
-//    @Tag(name = "chatting")
-//    @ApiOperation(value = "1:1 채팅 내역 API", notes = "채팅 내역 최신순으로 10개를 반환하며, 페이지 번호는 0부터 시작합니다.")
-//    @GetMapping("/chat/{page}")
-//    public ResponseEntity<BaseResponse<List<ChatRes.LoveChatRes>>>loadLoveChattingList(@PathVariable int page) {
-//
-//        List<ChatRes.LoveChatRes> chattingList = loveChatService.getChattingList(page);
-//
-//        return ResponseEntity.ok(BaseResponse.ok(BaseResponseStatus.SUCCESS, chattingList));
-//    }
+        String messageSendingTime = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:SSS").format(new Date());
+        otoChatService.saveChat(otoChatReq, messageSendingTime);
+
+        return new ChatRes.OTOChatRes().builder()
+                .memberNickname(otoChatReq.getMemberNickname())
+                .messageContent(otoChatReq.getMessageContent())
+                .messageSendingTime(messageSendingTime)
+                .build();
+    }
+
+//     1:1 채팅 내역을 불러오기 위한 API(http)
+    @Tag(name = "chatting")
+    @ApiOperation(value = "1:1 채팅 내역 API", notes = "채팅 내역 최신순으로 10개를 반환하며, 페이지 번호는 0부터 시작합니다.")
+    @GetMapping("/chat/{roomId}/{page}")
+    public ResponseEntity<BaseResponse<List<ChatRes.OTOChatRes>>>loadOTOChattingList(@PathVariable Long roomId, @PathVariable int page) {
+
+        List<ChatRes.OTOChatRes> chattingList = otoChatService.getChattingList(roomId,page);
+
+        return ResponseEntity.ok(BaseResponse.ok(BaseResponseStatus.SUCCESS, chattingList));
+    }
 }

--- a/src/main/java/com/app/univchat/controller/OTOChatController.java
+++ b/src/main/java/com/app/univchat/controller/OTOChatController.java
@@ -1,0 +1,69 @@
+package com.app.univchat.controller;
+
+import com.app.univchat.base.BaseResponse;
+import com.app.univchat.base.BaseResponseStatus;
+import com.app.univchat.dto.ChatReq;
+import com.app.univchat.dto.ChatRes;
+import com.app.univchat.dto.MemberReq;
+import com.app.univchat.service.LoveChatService;
+import com.app.univchat.service.OTOChatService;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+@Tag(name = "one_to_one_chat", description = "1:1 채팅 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/oto")
+public class OTOChatController {
+
+    private final OTOChatService otoChatService;
+
+    /*
+        1:1 채팅방 개설 api
+     */
+    @Tag(name = "one_to_one_chat")
+    @ApiOperation(value = "1:1 채팅방 개설 API")
+    @PostMapping("/room")
+    public BaseResponse<String> createChatRoom(@RequestBody ChatReq.OTOChatRoomReq otoChatRoomReq){
+
+//        ChatRes.OTOChatRoomRes otoChatRoomRes=otoChatService.createChatRoom(otoChatRoomReq);
+        return BaseResponse.ok(BaseResponseStatus.SUCCESS,otoChatService.createChatRoom(otoChatRoomReq));
+
+    }
+
+    // 연애상담 채팅 송신 및 저장을 위한 API(ws)
+//    @MessageMapping("/love")
+//    @SendTo("/sub/love")
+//    public ChatRes.LoveChatRes sendToLoveChattingRoom(ChatReq.LoveChatReq loveChatReq) {
+//
+//        String messageSendingTime = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:SSS").format(new Date());
+//        loveChatService.saveChat(loveChatReq, messageSendingTime);
+//
+//        return new ChatRes.LoveChatRes().builder()
+//                .memberNickname(loveChatReq.getMemberNickname())
+//                .messageContent(loveChatReq.getMessageContent())
+//                .messageSendingTime(messageSendingTime)
+//                .build();
+//    }
+
+    // 1:1 채팅 내역을 불러오기 위한 API(http)
+//    @Tag(name = "chatting")
+//    @ApiOperation(value = "1:1 채팅 내역 API", notes = "채팅 내역 최신순으로 10개를 반환하며, 페이지 번호는 0부터 시작합니다.")
+//    @GetMapping("/chat/{page}")
+//    public ResponseEntity<BaseResponse<List<ChatRes.LoveChatRes>>>loadLoveChattingList(@PathVariable int page) {
+//
+//        List<ChatRes.LoveChatRes> chattingList = loveChatService.getChattingList(page);
+//
+//        return ResponseEntity.ok(BaseResponse.ok(BaseResponseStatus.SUCCESS, chattingList));
+//    }
+}

--- a/src/main/java/com/app/univchat/domain/OTOChat.java
+++ b/src/main/java/com/app/univchat/domain/OTOChat.java
@@ -1,0 +1,33 @@
+package com.app.univchat.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "chatting_one_to_one")
+@ToString
+public class OTOChat {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long messageId;
+
+    @ManyToOne
+    @JoinColumn(name = "room_id", nullable = false)
+    public OTOChatRoom room;
+
+    @ManyToOne
+    @JoinColumn(name = "sender_id", nullable = false)
+    public Member member; // 메시지 송신자 식별자
+
+    @Column(nullable = false)
+    private String messageContent;
+
+    @Column(nullable = false)
+    private String messageSendingTime;
+
+}

--- a/src/main/java/com/app/univchat/domain/OTOChatRoom.java
+++ b/src/main/java/com/app/univchat/domain/OTOChatRoom.java
@@ -1,0 +1,33 @@
+package com.app.univchat.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "one_to_one_room")
+@ToString
+public class OTOChatRoom {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long roomId;
+
+    @ManyToOne
+    @JoinColumn(name = "sender_id", nullable = false)
+    public Member sender; // 메시지 송신자 식별자
+
+    @ManyToOne
+    @JoinColumn(name = "receive_id", nullable = false)
+    public Member receive; // 메시지 송신자 식별자
+
+    @Column(nullable = false)
+    private int visible;
+
+//    @Column(nullable = false)
+    private Long lastMessageId;
+
+}

--- a/src/main/java/com/app/univchat/dto/ChatReq.java
+++ b/src/main/java/com/app/univchat/dto/ChatReq.java
@@ -65,9 +65,36 @@ public class ChatReq {
         }
     }
 
-    /*
-        1:1 채팅방 개설 req
-     */
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Setter
+    @ApiModel(value = "OTOChatReq - 1:1 채팅 메시지 전송 객체")
+    public static class OTOChatReq extends ChatReq {
+
+        @ApiModelProperty(name = "채팅방 번호")
+        @NotNull
+        protected Long roomId; // 채팅방 id
+
+        @ApiModelProperty(name = "송신자 닉네임", example = "닉네임1")
+        @NotNull
+        protected String memberNickname; // 송신자 식별자
+
+        @ApiModelProperty(name = "채팅 내용", example = "채팅내용~~~")
+        @NotNull
+        protected String messageContent;
+
+        public OTOChat toEntity(Optional<OTOChatRoom> room,Optional<Member> member, String messageSendingTime) throws Exception {
+            return OTOChat.builder()
+                    .room(room.orElseThrow(() -> new Exception("존재하지 않는 회원입니다.")))
+                    .member(member.orElseThrow(() -> new Exception("존재하지 않는 회원입니다.")))
+                    .messageContent(messageContent)
+                    .messageSendingTime(messageSendingTime)
+                    .build();
+        }
+    }
+
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
@@ -83,9 +110,6 @@ public class ChatReq {
         @ApiModelProperty(name = "수신자 닉네임", example = "닉네임2")
         @NotNull
         protected String receiveNickname; // 수신자 식별자
-
-//        @ApiModelProperty(name = "볼 수 있는 상태 설정", notes = "0(모두 볼 수 있음), {나가지 않은 사람 id 개수}(나가지 않은 사람만 볼 수 있음), -1(모두 나간 경우 - 모두 볼 수 없음)")
-//        protected int visible; // 볼 수 있는 상태 설정
 
         public OTOChatRoom toEntity(Optional<Member> sender,Optional<Member> receive) throws Exception {
             return OTOChatRoom.builder()

--- a/src/main/java/com/app/univchat/dto/ChatReq.java
+++ b/src/main/java/com/app/univchat/dto/ChatReq.java
@@ -1,9 +1,6 @@
 package com.app.univchat.dto;
 
-import com.app.univchat.domain.DormChat;
-import com.app.univchat.domain.LoveChat;
-import com.app.univchat.domain.LiveChat;
-import com.app.univchat.domain.Member;
+import com.app.univchat.domain.*;
 import com.sun.istack.NotNull;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -64,6 +61,38 @@ public class ChatReq {
                     .member(member.orElseThrow(() -> new Exception("존재하지 않는 회원입니다.")))
                     .messageContent(messageContent)
                     .messageSendingTime(messageSendingTime)
+                    .build();
+        }
+    }
+
+    /*
+        1:1 채팅방 개설 req
+     */
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Setter
+    @ApiModel(value = "OTOChatRoomReq - 1:1 채팅방 개설 객체")
+    public static class OTOChatRoomReq extends ChatReq {
+
+        @ApiModelProperty(name = "송신자 닉네임", example = "닉네임1")
+        @NotNull
+        protected String senderNickname; // 송신자 식별자
+
+        @ApiModelProperty(name = "수신자 닉네임", example = "닉네임2")
+        @NotNull
+        protected String receiveNickname; // 수신자 식별자
+
+//        @ApiModelProperty(name = "볼 수 있는 상태 설정", notes = "0(모두 볼 수 있음), {나가지 않은 사람 id 개수}(나가지 않은 사람만 볼 수 있음), -1(모두 나간 경우 - 모두 볼 수 없음)")
+//        protected int visible; // 볼 수 있는 상태 설정
+
+        public OTOChatRoom toEntity(Optional<Member> sender,Optional<Member> receive) throws Exception {
+            return OTOChatRoom.builder()
+                    .sender(sender.orElseThrow(() -> new Exception("존재하지 않는 회원입니다.")))
+                    .receive(receive.orElseThrow(() -> new Exception("존재하지 않는 회원입니다.")))
+                    .visible(0)
+                    .lastMessageId(null)
                     .build();
         }
     }

--- a/src/main/java/com/app/univchat/dto/ChatRes.java
+++ b/src/main/java/com/app/univchat/dto/ChatRes.java
@@ -47,6 +47,18 @@ public class ChatRes {
     @AllArgsConstructor
     @Setter
     @Getter
+    // 1:1 채팅 메시지 객체
+    public static class OTOChatRes {
+        private String memberNickname; // 송신자 식별자
+        private String messageContent;
+        private String messageSendingTime;
+    }
+
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Setter
+    @Getter
     // 라이브 채팅 메시지 객체
     public static class OTOChatRoomRes {
         private Long roomId; // 채팅방 id

--- a/src/main/java/com/app/univchat/dto/ChatRes.java
+++ b/src/main/java/com/app/univchat/dto/ChatRes.java
@@ -41,4 +41,14 @@ public class ChatRes {
         private String messageContent;
         private String messageSendingTime;
     }
+
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Setter
+    @Getter
+    // 라이브 채팅 메시지 객체
+    public static class OTOChatRoomRes {
+        private Long roomId; // 채팅방 id
+    }
 }

--- a/src/main/java/com/app/univchat/repository/OTOChatRepository.java
+++ b/src/main/java/com/app/univchat/repository/OTOChatRepository.java
@@ -1,0 +1,12 @@
+package com.app.univchat.repository;
+
+import com.app.univchat.domain.LoveChat;
+import com.app.univchat.domain.OTOChat;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OTOChatRepository extends JpaRepository<OTOChat, Long> {
+//    Page<OTOChat> findAll(Pageable pageable);
+    Page<OTOChat> findByRoom(Long roomId, Pageable pageable);
+}

--- a/src/main/java/com/app/univchat/repository/OTOChatRepository.java
+++ b/src/main/java/com/app/univchat/repository/OTOChatRepository.java
@@ -1,12 +1,14 @@
 package com.app.univchat.repository;
 
-import com.app.univchat.domain.LoveChat;
 import com.app.univchat.domain.OTOChat;
+import com.app.univchat.domain.OTOChatRoom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface OTOChatRepository extends JpaRepository<OTOChat, Long> {
-//    Page<OTOChat> findAll(Pageable pageable);
-    Page<OTOChat> findByRoom(Long roomId, Pageable pageable);
+    Page<OTOChat> findAll(Pageable pageable);
+    Page<OTOChat> findByRoom(Optional<OTOChatRoom> room, Pageable pageable);
 }

--- a/src/main/java/com/app/univchat/repository/OTOChatRoomRepository.java
+++ b/src/main/java/com/app/univchat/repository/OTOChatRoomRepository.java
@@ -15,9 +15,9 @@ public interface OTOChatRoomRepository extends JpaRepository<OTOChatRoom, Long> 
 //    boolean existsBySender(Long id);
 
     // 수신자 존재 여부 확인
-    boolean existsBySenderAndReceive(Long sender, Long receive);
+//    boolean existsBySenderAndReceive(Long sender, Long receive);
 
     // 송신자, 수신자로 roomID 찾기
-    Optional<OTOChatRoom> findBySenderAndReceive(Long sender, Long receive);
+    Optional<OTOChatRoom> findBySenderAndReceive(Member sender, Member receive);
 
 }

--- a/src/main/java/com/app/univchat/repository/OTOChatRoomRepository.java
+++ b/src/main/java/com/app/univchat/repository/OTOChatRoomRepository.java
@@ -1,0 +1,23 @@
+package com.app.univchat.repository;
+
+import com.app.univchat.domain.Member;
+import com.app.univchat.domain.OTOChatRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OTOChatRoomRepository extends JpaRepository<OTOChatRoom, Long> {
+//    Page<OTOChatRoom> findAll(Pageable pageable);
+
+    // 송신자 존재 여부 확인
+//    boolean existsBySender(Long id);
+
+    // 수신자 존재 여부 확인
+    boolean existsBySenderAndReceive(Long sender, Long receive);
+
+    // 송신자, 수신자로 roomID 찾기
+    Optional<OTOChatRoom> findBySenderAndReceive(Long sender, Long receive);
+
+}

--- a/src/main/java/com/app/univchat/repository/OTOChatRoomRepository.java
+++ b/src/main/java/com/app/univchat/repository/OTOChatRoomRepository.java
@@ -20,6 +20,8 @@ public interface OTOChatRoomRepository extends JpaRepository<OTOChatRoom, Long> 
     // 송신자, 수신자로 채팅방 찾기
     Optional<OTOChatRoom> findBySenderAndReceive(Member sender, Member receive);
 
+    boolean existsBySenderAndReceive(Member sender, Member receive);
+
     // roomId로 채팅방 찾기
     Optional<OTOChatRoom> findByRoomId(Long roomId);
 

--- a/src/main/java/com/app/univchat/repository/OTOChatRoomRepository.java
+++ b/src/main/java/com/app/univchat/repository/OTOChatRoomRepository.java
@@ -17,7 +17,10 @@ public interface OTOChatRoomRepository extends JpaRepository<OTOChatRoom, Long> 
     // 수신자 존재 여부 확인
 //    boolean existsBySenderAndReceive(Long sender, Long receive);
 
-    // 송신자, 수신자로 roomID 찾기
+    // 송신자, 수신자로 채팅방 찾기
     Optional<OTOChatRoom> findBySenderAndReceive(Member sender, Member receive);
+
+    // roomId로 채팅방 찾기
+    Optional<OTOChatRoom> findByRoomId(Long roomId);
 
 }

--- a/src/main/java/com/app/univchat/service/OTOChatService.java
+++ b/src/main/java/com/app/univchat/service/OTOChatService.java
@@ -59,7 +59,6 @@ public class OTOChatService {
             if(foundRoom.isEmpty()) {
                 foundRoom=otoChatRoomRepository.findBySenderAndReceive(receive.get(),sender.get());
             }
-
         }
         else {  // 채팅방 개설
             otoChatRoomRepository.save(otoChatRoomReq.toEntity(sender,receive));
@@ -100,10 +99,11 @@ public class OTOChatService {
         Pageable pageable = PageRequest.of(page, 10,
                                     Sort.by("messageSendingTime").descending());
 
+        Optional<OTOChatRoom> room=otoChatRoomRepository.findByRoomId(roomId);
 
         // pagenation 한 채팅 목록을 modleMapper로 변환하여 반환
         return otoChatRepository
-                        .findByRoom(roomId,pageable)
+                        .findByRoom(room,pageable)
                         .stream()
                         .map(chat -> modelMapper.map(chat, ChatRes.OTOChatRes.class))
                         .collect(Collectors.toList());

--- a/src/main/java/com/app/univchat/service/OTOChatService.java
+++ b/src/main/java/com/app/univchat/service/OTOChatService.java
@@ -1,0 +1,102 @@
+package com.app.univchat.service;
+
+import com.app.univchat.domain.Member;
+import com.app.univchat.domain.OTOChatRoom;
+import com.app.univchat.dto.ChatReq;
+import com.app.univchat.dto.ChatRes;
+import com.app.univchat.dto.MemberRes;
+import com.app.univchat.repository.OTOChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class OTOChatService {
+
+    // MapperConfig에서 설정한 Mapper를 연결해주기 위함.
+    @Autowired
+    private final ModelMapper modelMapper;
+    private final MemberService memberService;
+    private final OTOChatRoomRepository otoChatRoomRepository;
+
+    /**
+     *  1:1 채팅방 개설
+     */
+    @SneakyThrows
+    @Transactional
+    public String createChatRoom(ChatReq.OTOChatRoomReq otoChatRoomReq) {
+
+        // nickname으로 송신자 member 객체 획득
+        String senderNickname = otoChatRoomReq.getSenderNickname();
+        Optional<Member> sender = memberService.getMember(senderNickname);
+
+        // nickname으로 수신자 member 객체 획득
+        String receiveNickname = otoChatRoomReq.getReceiveNickname();
+        Optional<Member> receive = memberService.getMember(receiveNickname);
+
+        // 송신자 - 수신자 쌍이 이미 존재하면 채팅방 개설 불가
+//        ChatRes.OTOChatRoomRes otoChatRoomRes = new ChatRes.OTOChatRoomRes();
+//        Long id1=sender.get().getId();
+//        Long id2=receive.get().getId();
+
+        // 이미 채팅방 존재하면 해당 채팅방 id return
+//        if(otoChatRoomRepository.existsBySenderAndReceive(id1,id2)) {
+//            Optional<OTOChatRoom> foundRoom=otoChatRoomRepository.findBySenderAndReceive(id1,id2);
+//
+//            otoChatRoomRes.setRoomId(foundRoom.get().getRoomId());
+//        }
+//        else if(otoChatRoomRepository.existsBySenderAndReceive(id2,id1)) {
+//            Optional<OTOChatRoom> foundRoom=otoChatRoomRepository.findBySenderAndReceive(id2,id1);
+//
+//            otoChatRoomRes.setRoomId(foundRoom.get().getRoomId());
+//        }
+//        else {  // 채팅방 개설
+            otoChatRoomRepository.save(otoChatRoomReq.toEntity(sender,receive));
+//            Optional<OTOChatRoom> foundRoom=otoChatRoomRepository.findBySenderAndReceive(id1,id2);
+//
+////            if(foundRoom.isEmpty()) System.out.println("엠티//////////////////");
+//            otoChatRoomRes.setRoomId(foundRoom.get().getRoomId());
+//        otoChatRoomRes.setRoomId(id1);
+////        }
+        return "채팅방이 개설되었습니다.";
+
+    }
+
+    /**
+     *  1:1 채팅 메시지 저장
+     */
+//    @SneakyThrows
+//    @Transactional
+//    public void saveChat(ChatReq.LoveChatReq loveChatReq, String messageSendingTime) {
+//
+//        // nickname으로 송신자 member 객체 획득
+//        String senderNickname = loveChatReq.getMemberNickname();
+//        Optional<Member> sender = memberService.getMember(senderNickname);
+//
+//        // 채팅 내역 저장
+//        loveChatRepository.save(loveChatReq.toEntity(sender, messageSendingTime));
+//    }
+
+    /**
+     *  연애상담 채팅 내역 조회
+     */
+//    public List<ChatRes.LoveChatRes> getChattingList(int page) {
+//
+//        // page는 요청하는 곳에 맞게, 한 번의 요청에는 10개의 채팅, 시간 내림차순으로 정렬.
+//        Pageable pageable = PageRequest.of(page, 10,
+//                                    Sort.by("messageSendingTime").descending());
+//
+//        // pagenation 한 채팅 목록을 modleMapper로 변환하여 반환
+//        return loveChatRepository
+//                        .findAll(pageable)
+//                        .stream()
+//                        .map(chat -> modelMapper.map(chat, ChatRes.LoveChatRes.class))
+//                        .collect(Collectors.toList());
+//    }
+}

--- a/src/main/java/com/app/univchat/service/OTOChatService.java
+++ b/src/main/java/com/app/univchat/service/OTOChatService.java
@@ -1,19 +1,27 @@
 package com.app.univchat.service;
 
 import com.app.univchat.domain.Member;
+import com.app.univchat.domain.OTOChat;
 import com.app.univchat.domain.OTOChatRoom;
 import com.app.univchat.dto.ChatReq;
 import com.app.univchat.dto.ChatRes;
 import com.app.univchat.dto.MemberRes;
+import com.app.univchat.repository.OTOChatRepository;
 import com.app.univchat.repository.OTOChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +32,7 @@ public class OTOChatService {
     private final ModelMapper modelMapper;
     private final MemberService memberService;
     private final OTOChatRoomRepository otoChatRoomRepository;
+    private final OTOChatRepository otoChatRepository;
 
     /**
      *  1:1 채팅방 개설
@@ -61,35 +70,42 @@ public class OTOChatService {
 
     }
 
+
+
     /**
      *  1:1 채팅 메시지 저장
      */
-//    @SneakyThrows
-//    @Transactional
-//    public void saveChat(ChatReq.LoveChatReq loveChatReq, String messageSendingTime) {
-//
-//        // nickname으로 송신자 member 객체 획득
-//        String senderNickname = loveChatReq.getMemberNickname();
-//        Optional<Member> sender = memberService.getMember(senderNickname);
-//
-//        // 채팅 내역 저장
-//        loveChatRepository.save(loveChatReq.toEntity(sender, messageSendingTime));
-//    }
+    @SneakyThrows
+    @Transactional
+    public void saveChat(ChatReq.OTOChatReq otoChatReq, String messageSendingTime) {
+
+        // nickname으로 송신자 member 객체 획득
+        String senderNickname = otoChatReq.getMemberNickname();
+        Optional<Member> sender = memberService.getMember(senderNickname);
+
+        // roomId로 채팅방 객체 획득
+        Long roomId=otoChatReq.getRoomId();
+        Optional<OTOChatRoom> room=otoChatRoomRepository.findByRoomId(roomId);
+
+        // 채팅 내역 저장
+        otoChatRepository.save(otoChatReq.toEntity(room, sender ,messageSendingTime));
+    }
 
     /**
      *  1:1 채팅 내역 조회
      */
-//    public List<ChatRes.LoveChatRes> getChattingList(int page) {
-//
-//        // page는 요청하는 곳에 맞게, 한 번의 요청에는 10개의 채팅, 시간 내림차순으로 정렬.
-//        Pageable pageable = PageRequest.of(page, 10,
-//                                    Sort.by("messageSendingTime").descending());
-//
-//        // pagenation 한 채팅 목록을 modleMapper로 변환하여 반환
-//        return loveChatRepository
-//                        .findAll(pageable)
-//                        .stream()
-//                        .map(chat -> modelMapper.map(chat, ChatRes.LoveChatRes.class))
-//                        .collect(Collectors.toList());
-//    }
+    public List<ChatRes.OTOChatRes> getChattingList(Long roomId,int page) {
+
+        // page는 요청하는 곳에 맞게, 한 번의 요청에는 10개의 채팅, 시간 내림차순으로 정렬.
+        Pageable pageable = PageRequest.of(page, 10,
+                                    Sort.by("messageSendingTime").descending());
+
+
+        // pagenation 한 채팅 목록을 modleMapper로 변환하여 반환
+        return otoChatRepository
+                        .findByRoom(roomId,pageable)
+                        .stream()
+                        .map(chat -> modelMapper.map(chat, ChatRes.OTOChatRes.class))
+                        .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/app/univchat/service/OTOChatService.java
+++ b/src/main/java/com/app/univchat/service/OTOChatService.java
@@ -30,7 +30,7 @@ public class OTOChatService {
      */
     @SneakyThrows
     @Transactional
-    public String createChatRoom(ChatReq.OTOChatRoomReq otoChatRoomReq) {
+    public ChatRes.OTOChatRoomRes createChatRoom(ChatReq.OTOChatRoomReq otoChatRoomReq) {
 
         // nickname으로 송신자 member 객체 획득
         String senderNickname = otoChatRoomReq.getSenderNickname();
@@ -41,30 +41,23 @@ public class OTOChatService {
         Optional<Member> receive = memberService.getMember(receiveNickname);
 
         // 송신자 - 수신자 쌍이 이미 존재하면 채팅방 개설 불가
-//        ChatRes.OTOChatRoomRes otoChatRoomRes = new ChatRes.OTOChatRoomRes();
-//        Long id1=sender.get().getId();
-//        Long id2=receive.get().getId();
+        ChatRes.OTOChatRoomRes otoChatRoomRes = new ChatRes.OTOChatRoomRes();
 
         // 이미 채팅방 존재하면 해당 채팅방 id return
-//        if(otoChatRoomRepository.existsBySenderAndReceive(id1,id2)) {
-//            Optional<OTOChatRoom> foundRoom=otoChatRoomRepository.findBySenderAndReceive(id1,id2);
-//
-//            otoChatRoomRes.setRoomId(foundRoom.get().getRoomId());
-//        }
-//        else if(otoChatRoomRepository.existsBySenderAndReceive(id2,id1)) {
-//            Optional<OTOChatRoom> foundRoom=otoChatRoomRepository.findBySenderAndReceive(id2,id1);
-//
-//            otoChatRoomRes.setRoomId(foundRoom.get().getRoomId());
-//        }
-//        else {  // 채팅방 개설
+        Optional<OTOChatRoom> foundRoom;
+        if(otoChatRoomRepository.findBySenderAndReceive(sender.get(),receive.get())!=null) {
+            foundRoom=otoChatRoomRepository.findBySenderAndReceive(sender.get(),receive.get());
+            if(foundRoom.isEmpty()) {
+                foundRoom=otoChatRoomRepository.findBySenderAndReceive(receive.get(),sender.get());
+            }
+
+        }
+        else {  // 채팅방 개설
             otoChatRoomRepository.save(otoChatRoomReq.toEntity(sender,receive));
-//            Optional<OTOChatRoom> foundRoom=otoChatRoomRepository.findBySenderAndReceive(id1,id2);
-//
-////            if(foundRoom.isEmpty()) System.out.println("엠티//////////////////");
-//            otoChatRoomRes.setRoomId(foundRoom.get().getRoomId());
-//        otoChatRoomRes.setRoomId(id1);
-////        }
-        return "채팅방이 개설되었습니다.";
+            foundRoom=otoChatRoomRepository.findBySenderAndReceive(sender.get(),receive.get());
+        }
+        otoChatRoomRes.setRoomId(foundRoom.get().getRoomId());
+        return otoChatRoomRes;
 
     }
 
@@ -84,7 +77,7 @@ public class OTOChatService {
 //    }
 
     /**
-     *  연애상담 채팅 내역 조회
+     *  1:1 채팅 내역 조회
      */
 //    public List<ChatRes.LoveChatRes> getChattingList(int page) {
 //

--- a/src/main/resources/static/chattingList.html
+++ b/src/main/resources/static/chattingList.html
@@ -6,6 +6,7 @@
   <script src="/dormChat.js"></script>
   <script src="/loveChat.js"></script>
   <script src="/liveChat.js"></script>
+  <script src="/otoChat.js"></script>
   <script src="/webjars/jquery/jquery.min.js"></script>
   <script src="/webjars/sockjs-client/sockjs.min.js"></script>
   <script src="/webjars/stomp-websocket/stomp.min.js"></script>
@@ -17,7 +18,7 @@
     <li><a class="chat-room" href="#" onclick="enterDormChattingRoom()">Dorm Chatting</a></li>
     <li><a class="chat-room" href="#" onclick="enterLoveChattingRoom()">Dating Counseling Chatting</a></li>
     <li><a class="chat-room" href="#" onclick="enterLiveChattingRoom()">Live Chatting</a></li>
-    <li><a class="chat-room" href="#">One-on-One Chatting</a></li>
+    <li><a class="chat-room" href="#" onclick="enterOTOChattingRoom()">One-on-One Chatting</a></li>
   </ul>
   <div id="dorm-chat" class="dorm-chat"></div>
 </div>

--- a/src/main/resources/static/otoChat.html
+++ b/src/main/resources/static/otoChat.html
@@ -16,6 +16,7 @@
     <div class="message-input">
       <label for="room_id">Room ID:</label>
       <input type="text" id="room_id" class="room_id-input">
+      <button id="send-id" class="send-id-btn" onclick="sendId()">Enter Chatting Room</button>
       <label for="sender">Sender:</label>
       <input type="text" id="sender" class="sender-input">
       <label for="message">Message:</label>

--- a/src/main/resources/static/otoChat.html
+++ b/src/main/resources/static/otoChat.html
@@ -1,0 +1,30 @@
+ <!DOCTYPE html>
+  <html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Chat Room</title>
+    <script src="/otoChat.js"></script>
+    <script src="/webjars/jquery/jquery.min.js"></script>
+    <script src="/webjars/sockjs-client/sockjs.min.js"></script>
+    <script src="/webjars/stomp-websocket/stomp.min.js"></script>
+    <link href="/dormChatStyle.css" rel="stylesheet">
+  </head>
+<body>
+  <div class="chat-room">
+    <h3 class="chat-title">One-to-One Chatting</h3>
+
+    <div class="message-input">
+      <label for="room_id">Room ID:</label>
+      <input type="text" id="room_id" class="room_id-input">
+      <label for="sender">Sender:</label>
+      <input type="text" id="sender" class="sender-input">
+      <label for="message">Message:</label>
+      <input type="text" id="message" class="message-input">
+      <button id="send-message" class="send-message-btn" onclick="sendMessage_oto()">Send Message</button>
+    </div>
+    <div id="message-list" class="message-list">
+      <!-- message tags will be added here -->
+    </div>
+  </div>
+</body>
+</html>

--- a/src/main/resources/static/otoChat.js
+++ b/src/main/resources/static/otoChat.js
@@ -1,32 +1,32 @@
 // 1:1 상담 채팅
 const enterOTOChattingRoom = () => {
 
-    let socket = new SockJS(`/chat/`);
-
-    // SockJS를 바탕으로 stompClient 생성
-    stompClient = Stomp.over(socket);
-
-    // stomp.js 에서 제공하는 콘솔창 로그 설정을 제어할 수 있는 함수
-    // 개발 시에는 로그를 보며, 이해하고
-    // 배포 시 아래처럼 설정하여 콘솔창에 보이지 않게 설정한다.
-    stompClient.debug = (res) => {};
-
-    // 기숙사 채팅방 입장(내부적으로 웹소켓 연결)
-    stompClient.connect(header,
-        // 연결 성공 시 실행하는 함수
-        (res) => {
-            // console.log('Connected: ' + res);
-            // 기숙사 채팅방을 구독 => 기숙사 채팅방으로 오는 메세지를 수신하겠다는 의미
-            stompClient.subscribe(`/sub/oto`, (stompResponse) => {
-
-                // 메세지 전송 성공 시 메세지 내용을 전달
-                if (stompResponse.command === "MESSAGE") {
-                    receiveMessage(JSON.parse(stompResponse.body));
-                }
-            });
-
-            // a 태그로 페이지 이동 시 stompClient 값이 초기화되므로 하는 행동
-            // 페이지 이동이 아닌, 한 페이지에서 동작하게 함.
+//    let socket = new SockJS(`/chat/`);
+//
+//    // SockJS를 바탕으로 stompClient 생성
+//    stompClient = Stomp.over(socket);
+//
+//    // stomp.js 에서 제공하는 콘솔창 로그 설정을 제어할 수 있는 함수
+//    // 개발 시에는 로그를 보며, 이해하고
+//    // 배포 시 아래처럼 설정하여 콘솔창에 보이지 않게 설정한다.
+//    stompClient.debug = (res) => {};
+//
+//    // 기숙사 채팅방 입장(내부적으로 웹소켓 연결)
+//    stompClient.connect(header,
+//        // 연결 성공 시 실행하는 함수
+//        (res) => {
+//            // console.log('Connected: ' + res);
+//            // 기숙사 채팅방을 구독 => 기숙사 채팅방으로 오는 메세지를 수신하겠다는 의미
+//            stompClient.subscribe(`/sub/oto`, (stompResponse) => {
+//
+//                // 메세지 전송 성공 시 메세지 내용을 전달
+//                if (stompResponse.command === "MESSAGE") {
+//                    receiveMessage(JSON.parse(stompResponse.body));
+//                }
+//            });
+//
+//            // a 태그로 페이지 이동 시 stompClient 값이 초기화되므로 하는 행동
+//            // 페이지 이동이 아닌, 한 페이지에서 동작하게 함.
             fetch('/otoChat.html')
                 .then(res => res.text())
                 .then(html => {
@@ -34,33 +34,33 @@ const enterOTOChattingRoom = () => {
                     content.innerHTML = html;
                 })
                 .catch(err => console.error(err));
-
-            // 최근 채팅 내역을 불러 오는 부분
-            // 임의로 페이지를 설정함(가장 최근 10개 -> 페이지 0)
-            // 무한 스크롤 등을 구현하여, page 별로 요청하면 됨.
-            const page = 0;
-            const room= parseInt($("#room_id").val())
-            fetch(`http://localhost:8080/oto/chat/${room}/${page}`)
-                .then(res => res.json())
-                .then(data => {
-                    data.result.reverse().forEach((message) => {
-                        $("#message-list").append("<tr><td>"
-                            + message.messageSendingTime + " / "
-                            + message.memberNickname + " / "
-                            + message.messageContent + "</td></tr>");
-                    })
-                })
-            }
-
-        // 연결 실패(ERROR) 시 실행할 함수
-        ,(err) => {
-            alert("연결에 실패 했습니다!");
-    });
-
-    // 웹소켓 연결 종료 시 실행되는 함수
-    stompClient.ws.onclose = () => {
-        console.log("웹소켓 연결이 종료되었습니다.");
-    }
+//
+////            // 최근 채팅 내역을 불러 오는 부분
+////            // 임의로 페이지를 설정함(가장 최근 10개 -> 페이지 0)
+////            // 무한 스크롤 등을 구현하여, page 별로 요청하면 됨.
+////            const page = 0;
+////            const room= parseInt($("#room_id").val())
+////            fetch(`http://localhost:8080/oto/chat/${room}/${page}`)
+////                .then(res => res.json())
+////                .then(data => {
+////                    data.result.reverse().forEach((message) => {
+////                        $("#message-list").append("<tr><td>"
+////                            + message.messageSendingTime + " / "
+////                            + message.memberNickname + " / "
+////                            + message.messageContent + "</td></tr>");
+////                    })
+////                })
+////            }
+//
+//        // 연결 실패(ERROR) 시 실행할 함수
+//        ,(err) => {
+//            alert("연결에 실패 했습니다!");
+//    });
+//
+//    // 웹소켓 연결 종료 시 실행되는 함수
+//    stompClient.ws.onclose = () => {
+//        console.log("웹소켓 연결이 종료되었습니다.");
+//    }
 }
 
 // 메세지 송신을 위해 실행해야 하는 함수
@@ -88,6 +88,71 @@ function receiveMessage(message) {
         + message.messageSendingTime + " / "
         + message.memberNickname + " / "
         + message.messageContent + "</td></tr>");
+}
+
+// 채팅방 입장
+function sendId() {
+
+     let socket = new SockJS(`/chat/`);
+
+        // SockJS를 바탕으로 stompClient 생성
+        stompClient = Stomp.over(socket);
+
+        // stomp.js 에서 제공하는 콘솔창 로그 설정을 제어할 수 있는 함수
+        // 개발 시에는 로그를 보며, 이해하고
+        // 배포 시 아래처럼 설정하여 콘솔창에 보이지 않게 설정한다.
+        stompClient.debug = (res) => {};
+
+        // 기숙사 채팅방 입장(내부적으로 웹소켓 연결)
+        stompClient.connect(header,
+            // 연결 성공 시 실행하는 함수
+            (res) => {
+                // console.log('Connected: ' + res);
+                // 기숙사 채팅방을 구독 => 기숙사 채팅방으로 오는 메세지를 수신하겠다는 의미
+                stompClient.subscribe(`/sub/oto`, (stompResponse) => {
+
+                    // 메세지 전송 성공 시 메세지 내용을 전달
+                    if (stompResponse.command === "MESSAGE") {
+                        receiveMessage(JSON.parse(stompResponse.body));
+                    }
+                });
+
+                // a 태그로 페이지 이동 시 stompClient 값이 초기화되므로 하는 행동
+                // 페이지 이동이 아닌, 한 페이지에서 동작하게 함.
+                fetch('/otoChat.html')
+                    .then(res => res.text())
+                    .then(html => {
+                        const content = document.getElementById('dorm-chat');
+                        content.innerHTML = html;
+                    })
+                    .catch(err => console.error(err));
+
+    //            // 최근 채팅 내역을 불러 오는 부분
+    //            // 임의로 페이지를 설정함(가장 최근 10개 -> 페이지 0)
+    //            // 무한 스크롤 등을 구현하여, page 별로 요청하면 됨.
+                const page = 0;
+                const room= parseInt($("#room_id").val())
+                fetch(`http://localhost:8080/oto/chat/${room}/${page}`)
+                    .then(res => res.json())
+                    .then(data => {
+                        data.result.reverse().forEach((message) => {
+                            $("#message-list").append("<tr><td>"
+                                + message.messageSendingTime + " / "
+                                + message.memberNickname + " / "
+                                + message.messageContent + "</td></tr>");
+                        })
+                    })
+                }
+
+            // 연결 실패(ERROR) 시 실행할 함수
+            ,(err) => {
+                alert("연결에 실패 했습니다!");
+        });
+
+        // 웹소켓 연결 종료 시 실행되는 함수
+        stompClient.ws.onclose = () => {
+            console.log("웹소켓 연결이 종료되었습니다.");
+        }
 }
 
 function disconnect() {

--- a/src/main/resources/static/otoChat.js
+++ b/src/main/resources/static/otoChat.js
@@ -1,0 +1,98 @@
+// 1:1 상담 채팅
+const enterOTOChattingRoom = () => {
+
+    let socket = new SockJS(`/chat/`);
+
+    // SockJS를 바탕으로 stompClient 생성
+    stompClient = Stomp.over(socket);
+
+    // stomp.js 에서 제공하는 콘솔창 로그 설정을 제어할 수 있는 함수
+    // 개발 시에는 로그를 보며, 이해하고
+    // 배포 시 아래처럼 설정하여 콘솔창에 보이지 않게 설정한다.
+    stompClient.debug = (res) => {};
+
+    // 기숙사 채팅방 입장(내부적으로 웹소켓 연결)
+    stompClient.connect(header,
+        // 연결 성공 시 실행하는 함수
+        (res) => {
+            // console.log('Connected: ' + res);
+            // 기숙사 채팅방을 구독 => 기숙사 채팅방으로 오는 메세지를 수신하겠다는 의미
+            stompClient.subscribe(`/sub/oto`, (stompResponse) => {
+
+                // 메세지 전송 성공 시 메세지 내용을 전달
+                if (stompResponse.command === "MESSAGE") {
+                    receiveMessage(JSON.parse(stompResponse.body));
+                }
+            });
+
+            // a 태그로 페이지 이동 시 stompClient 값이 초기화되므로 하는 행동
+            // 페이지 이동이 아닌, 한 페이지에서 동작하게 함.
+            fetch('/otoChat.html')
+                .then(res => res.text())
+                .then(html => {
+                    const content = document.getElementById('dorm-chat');
+                    content.innerHTML = html;
+                })
+                .catch(err => console.error(err));
+
+            // 최근 채팅 내역을 불러 오는 부분
+            // 임의로 페이지를 설정함(가장 최근 10개 -> 페이지 0)
+            // 무한 스크롤 등을 구현하여, page 별로 요청하면 됨.
+            const page = 0;
+            const room= parseInt($("#room_id").val())
+            fetch(`http://localhost:8080/oto/chat/${room}/${page}`)
+                .then(res => res.json())
+                .then(data => {
+                    data.result.reverse().forEach((message) => {
+                        $("#message-list").append("<tr><td>"
+                            + message.messageSendingTime + " / "
+                            + message.memberNickname + " / "
+                            + message.messageContent + "</td></tr>");
+                    })
+                })
+            }
+
+        // 연결 실패(ERROR) 시 실행할 함수
+        ,(err) => {
+            alert("연결에 실패 했습니다!");
+    });
+
+    // 웹소켓 연결 종료 시 실행되는 함수
+    stompClient.ws.onclose = () => {
+        console.log("웹소켓 연결이 종료되었습니다.");
+    }
+}
+
+// 메세지 송신을 위해 실행해야 하는 함수
+function sendMessage_oto() {
+    const message = {
+        roomId: $("#room_id").val(),
+        memberNickname: $("#sender").val(),
+        messageContent: $("#message").val(),
+    }
+
+    // 첫 번째 인자: 메시지를 보내기 위한 url
+    // 두 번째 인자: 헤더
+    // 세 번쨰 인자: 보낼 메세지
+    // 메세지를 직렬화해서 보내야 함.
+    stompClient.send(`/pub/oto`, header, JSON.stringify(message));
+}
+
+// 메세지 송신 성공하면, 메세지를 반환함.
+function receiveMessage(message) {
+
+    // messageRes 객체
+    // console.log(message)
+
+    $("#message-list").append("<tr><td>"
+        + message.messageSendingTime + " / "
+        + message.memberNickname + " / "
+        + message.messageContent + "</td></tr>");
+}
+
+function disconnect() {
+    if (stompClient !== null) {
+        stompClient.disconnect();
+    }
+    // console.log("Disconnected");
+}


### PR DESCRIPTION
이번주 구현 완료 

- [x] 1:1 채팅에 필요한 엔티티 구현
- [x] 채팅방 개설 api 구현
- [x] `roomId` 로 채팅방 입장 web controller 구현
- [x] 채팅방에 입장한 후 발송한 1:1 채팅 내용 저장 구현
- [x] 채팅방에 입장했을 때 해당 채팅방의 채팅내역 리스트 반환 구현

향후 구현할 부분
- [ ] 유저가 참여한 1:1 채팅방 목록 조회
- [ ] 유저가 참여한 1:1 채팅방의 최신 메시지 포함하여 조회
- [ ] 채팅 상대가 나갔을 때 visible 처리
- [ ] 1:1 채팅방에 아무도 남지 않았을 때 visible 처리