### PR TITLE
Feature/#74 member API 에러 핸들링 코드 수정 & 채팅 내역 리스트 조회 URI 변경

### DIFF
--- a/src/main/java/com/app/univchat/base/BaseResponseStatus.java
+++ b/src/main/java/com/app/univchat/base/BaseResponseStatus.java
@@ -25,7 +25,7 @@ public enum  BaseResponseStatus {
     /**
      * 2000 : User 오류
      */
-    USER_EXISTS_NICKNAME_ERROR("2001","중복된 닉네임입니다.", 409),
+    USER_EXISTS_NICKNAME_ERROR("2001","중복된 닉네임입니다.", 400),
 
     USER_FAILED_TO_LOG_IN_ERROR("2002", "로그인에 실패하였습니다.", 400),
 

--- a/src/main/java/com/app/univchat/config/SecurityConfig.java
+++ b/src/main/java/com/app/univchat/config/SecurityConfig.java
@@ -97,7 +97,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 // 채팅 엔드포인트, 기숙사 채팅 기록 조회 인증 x
                 .antMatchers("/chat/**").permitAll()
                 .antMatchers("/oto/**").permitAll()
-                .antMatchers("/dorm/chat/**", "/live/chat/**", "/love/chat/**").permitAll()
+                .antMatchers("/chatting/**").permitAll()
 
                 .anyRequest().authenticated() //위의 api가 아닌 경로는 모두 jwt 토큰 인증을 해야 함
 

--- a/src/main/java/com/app/univchat/controller/DormChatController.java
+++ b/src/main/java/com/app/univchat/controller/DormChatController.java
@@ -26,7 +26,7 @@ import java.util.List;
 @Tag(name = "chatting", description = "채팅 내역 조회 API")
 @Controller
 @RequiredArgsConstructor
-@RequestMapping("/dorm")
+@RequestMapping("/chatting/dorm")
 public class DormChatController {
 
     private final DormChatService dormChatService;
@@ -49,7 +49,7 @@ public class DormChatController {
     // 기숙사 채팅 내역을 불러오기 위한 API(http)
     @Tag(name = "chatting")
     @ApiOperation(value = "기숙사 채팅 내역 API", notes = "채팅 내역 최신순으로 10개를 반환하며, 페이지 번호는 0부터 시작합니다.")
-    @GetMapping("/chat/{page}")
+    @GetMapping("/{page}")
     public ResponseEntity<BaseResponse<List<ChatRes.DormChatRes>>>loadDormChattingList(@PathVariable int page) {
 
         List<ChatRes.DormChatRes> chattingList = dormChatService.getChattingList(page);

--- a/src/main/java/com/app/univchat/controller/LoveChatController.java
+++ b/src/main/java/com/app/univchat/controller/LoveChatController.java
@@ -23,7 +23,7 @@ import java.util.List;
 @Tag(name = "chatting", description = "채팅 내역 조회 API")
 @Controller
 @RequiredArgsConstructor
-@RequestMapping("/love")
+@RequestMapping("/chatting/love")
 public class LoveChatController {
 
     private final LoveChatService loveChatService;
@@ -46,7 +46,7 @@ public class LoveChatController {
     // 연애상담 채팅 내역을 불러오기 위한 API(http)
     @Tag(name = "chatting")
     @ApiOperation(value = "기숙사 채팅 내역 API", notes = "채팅 내역 최신순으로 10개를 반환하며, 페이지 번호는 0부터 시작합니다.")
-    @GetMapping("/chat/{page}")
+    @GetMapping("/{page}")
     public ResponseEntity<BaseResponse<List<ChatRes.LoveChatRes>>>loadLoveChattingList(@PathVariable int page) {
 
         List<ChatRes.LoveChatRes> chattingList = loveChatService.getChattingList(page);

--- a/src/main/java/com/app/univchat/controller/MemberController.java
+++ b/src/main/java/com/app/univchat/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.app.univchat.controller;
 
+import com.app.univchat.base.BaseException;
 import com.app.univchat.base.BaseResponse;
 import com.app.univchat.base.BaseResponseStatus;
 
@@ -62,11 +63,11 @@ public class MemberController {
 
         // 이메일 중복 체크
         if(memberService.checkEmail(memberDto.getEmail())) {
-            return BaseResponse.ok(BaseResponseStatus.USER_ALREADY_EXIST_USERNAME);
+            throw new BaseException(BaseResponseStatus.USER_ALREADY_EXIST_USERNAME);
         }
         // 닉네임 중복 체크
         if(memberService.checkNickname(memberDto.getNickname())) {
-            return BaseResponse.ok(BaseResponseStatus.USER_EXISTS_NICKNAME_ERROR);
+            throw new BaseException(BaseResponseStatus.USER_EXISTS_NICKNAME_ERROR);
         }
 
         return BaseResponse.ok(BaseResponseStatus.SUCCESS,memberService.signup(memberDto));
@@ -79,14 +80,9 @@ public class MemberController {
     @PostMapping("/change/password")
     public BaseResponse<String> updatePassword(@RequestBody MemberReq.UpdatePasswordReq updatePasswordReq){
 
-        String passwordRes=memberService.updatePassword(updatePasswordReq);
+        memberService.updatePassword(updatePasswordReq);
 
-        if(passwordRes!=null) {
-            return BaseResponse.ok(BaseResponseStatus.SUCCESS,passwordRes);
-        }
-        else {
-            return BaseResponse.ok(BaseResponseStatus.USER_NOT_EXIST_EMAIL_ERROR);
-        }
+        return BaseResponse.ok(BaseResponseStatus.SUCCESS);
 
     }
 
@@ -94,9 +90,9 @@ public class MemberController {
     @ApiOperation(value = "회원조회 API")
     @GetMapping("/info")
     public BaseResponse<MemberRes.InfoRes> viewInfo(@ApiIgnore @AuthenticationPrincipal PrincipalDetails member) throws IOException {
-        MemberRes.InfoRes infoRes=memberService.viewInfo(member.getMember());
+        MemberRes.InfoRes infoRes = memberService.viewInfo(member.getMember());
 
-        return BaseResponse.ok(BaseResponseStatus.SUCCESS,infoRes);
+        return BaseResponse.ok(BaseResponseStatus.SUCCESS, infoRes);
     }
 
     /**
@@ -123,7 +119,7 @@ public class MemberController {
             @ApiResponse(code = 415, message = "Content type 'application/octet-stream' not supported")
     })
     @PutMapping("/info")
-    public ResponseEntity<BaseResponse<MemberRes.Update>> update(@RequestPart MemberReq.Update memberUpdateDto,
+    public BaseResponse<MemberRes.Update> update(@RequestPart MemberReq.Update memberUpdateDto,
                                     @RequestPart(required = false) MultipartFile profileImage,
                                     @ApiIgnore @AuthenticationPrincipal PrincipalDetails member){
 
@@ -133,7 +129,7 @@ public class MemberController {
 
         MemberRes.Update result = memberService.update(memberUpdateDto, member.getMember());
 
-        return ResponseEntity.ok(BaseResponse.ok(BaseResponseStatus.SUCCESS, result));
+        return BaseResponse.ok(BaseResponseStatus.SUCCESS, result);
     }
 
 
@@ -148,10 +144,10 @@ public class MemberController {
         String redisRT = redisService.getValues(String.valueOf(postReIssueReq.getEmail()));
 
         if (redisRT == null) {
-            return BaseResponse.ok(BaseResponseStatus.JWT_INVALID_REFRESH_TOKEN);
+            throw new BaseException(BaseResponseStatus.JWT_INVALID_REFRESH_TOKEN);
         }
         if (!redisRT.equals(postReIssueReq.getRefreshToken())) {
-            return BaseResponse.ok(BaseResponseStatus.JWT_INVALID_USER_JWT);
+            throw new BaseException(BaseResponseStatus.JWT_INVALID_USER_JWT);
         }
 
         MemberRes.PostReIssueRes postReIssueRes = memberService.reIssueToken(postReIssueReq.getEmail());

--- a/src/main/java/com/app/univchat/controller/chat/LiveChatController.java
+++ b/src/main/java/com/app/univchat/controller/chat/LiveChatController.java
@@ -23,7 +23,7 @@ import java.util.List;
 @Tag(name = "chatting", description = "채팅 내역 조회 API")
 @Controller
 @RequiredArgsConstructor
-@RequestMapping("/live")
+@RequestMapping("/chatting/live")
 public class LiveChatController {
 
     private final LiveChatService liveChatService;
@@ -43,7 +43,7 @@ public class LiveChatController {
 
     @Tag(name = "chatting")
     @ApiOperation(value = "라이브 채팅 내역 API", notes = "채팅 내역 최신순으로 10개를 반환하며, 페이지 번호는 0부터 시작합니다.")
-    @GetMapping("/chat/{page}")
+    @GetMapping("/{page}")
     public ResponseEntity<BaseResponse<List<ChatRes.LiveChatRes>>> loadLiveChattingList(@PathVariable int page) {
         List<ChatRes.LiveChatRes> chattingList = liveChatService.getChattingList(page, 10);
 

--- a/src/main/java/com/app/univchat/domain/OTOChatRoom.java
+++ b/src/main/java/com/app/univchat/domain/OTOChatRoom.java
@@ -24,8 +24,8 @@ public class OTOChatRoom {
     @JoinColumn(name = "receive_id", nullable = false)
     public Member receive; // 메시지 송신자 식별자
 
-    @Column(nullable = false)
-    private int visible;
+//    @Column(nullable = false)
+//    private int visible;
 
 //    @Column(nullable = false)
     private Long lastMessageId;

--- a/src/main/java/com/app/univchat/dto/ChatReq.java
+++ b/src/main/java/com/app/univchat/dto/ChatReq.java
@@ -115,7 +115,7 @@ public class ChatReq {
             return OTOChatRoom.builder()
                     .sender(sender.orElseThrow(() -> new Exception("존재하지 않는 회원입니다.")))
                     .receive(receive.orElseThrow(() -> new Exception("존재하지 않는 회원입니다.")))
-                    .visible(0)
+//                    .visible(0)
                     .lastMessageId(null)
                     .build();
         }

--- a/src/main/java/com/app/univchat/service/MemberService.java
+++ b/src/main/java/com/app/univchat/service/MemberService.java
@@ -3,6 +3,7 @@ package com.app.univchat.service;
 import com.app.univchat.aws.AWSS3Uploader;
 import com.app.univchat.base.BaseException;
 
+import com.app.univchat.base.BaseResponseStatus;
 import com.app.univchat.config.SecurityUtil;
 
 import com.app.univchat.domain.Member;
@@ -80,7 +81,7 @@ public class MemberService {
      */
     public MemberRes.InfoRes viewInfo(Member member) throws IOException{
 
-        MemberRes.InfoRes infoRes=new MemberRes.InfoRes();
+        MemberRes.InfoRes infoRes = new MemberRes.InfoRes();
 
         infoRes.setEmail(member.getEmail());
         infoRes.setNickname(member.getNickname());
@@ -126,22 +127,16 @@ public class MemberService {
     /**
      * 비밀번호 변경
      */
-    public String updatePassword(MemberReq.UpdatePasswordReq updatePasswordReq) throws BaseException {
+    public void updatePassword(MemberReq.UpdatePasswordReq updatePasswordReq) throws BaseException {
 
         Optional<Member> foundMember=memberRepository.findByEmail(updatePasswordReq.getEmail());
+        Member member = foundMember.orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_EXIST_EMAIL_ERROR));
 
-        if(foundMember!=null) {
-            BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-            String encPassword=passwordEncoder.encode(updatePasswordReq.getPassword());
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        String encPassword=passwordEncoder.encode(updatePasswordReq.getPassword());
+        member.updatePassword(encPassword);
+        memberRepository.save(member);
 
-            Member member=foundMember.get();
-            member.updatePassword(encPassword);
-            memberRepository.save(member);
-            return "비밀번호가 변경되었습니다.";
-        }
-        else{
-            return null;
-        }
     }
 
     public boolean checkEmail(String email) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL5Dialect

--- a/src/main/resources/static/dormChat.js
+++ b/src/main/resources/static/dormChat.js
@@ -19,7 +19,7 @@ const enterDormChattingRoom = () => {
     // stomp.js 에서 제공하는 콘솔창 로그 설정을 제어할 수 있는 함수
     // 개발 시에는 로그를 보며, 이해하고
     // 배포 시 아래처럼 설정하여 콘솔창에 보이지 않게 설정한다.
-    stompClient.debug = (res) => {};
+//    stompClient.debug = (res) => {};
 
     // 기숙사 채팅방 입장(내부적으로 웹소켓 연결)
     stompClient.connect(header,
@@ -49,7 +49,7 @@ const enterDormChattingRoom = () => {
             // 임의로 페이지를 설정함(가장 최근 10개 -> 페이지 0)
             // 무한 스크롤 등을 구현하여, page 별로 요청하면 됨.
             const page = 0;
-            fetch(`http://localhost:8080/dorm/chat/${page}`)
+            fetch(`http://localhost:8080/chatting/dorm/${page}`)
                 .then(res => res.json())
                 .then(data => {
                     data.result.reverse().forEach((message) => {

--- a/src/main/resources/static/liveChat.js
+++ b/src/main/resources/static/liveChat.js
@@ -39,7 +39,7 @@ const enterLiveChattingRoom = () => {
 
             // 최근 채팅 내역을 불러 오는 부분
             const page = 0;
-            fetch(`http://localhost:8080/live/chat/${page}`)
+            fetch(`http://localhost:8080/chatting/live/${page}`)
                 .then(res => res.json())
                 .then(data => {
                     data.result.reverse().forEach((message) => {

--- a/src/main/resources/static/loveChat.js
+++ b/src/main/resources/static/loveChat.js
@@ -39,7 +39,7 @@ const enterLoveChattingRoom = () => {
             // 임의로 페이지를 설정함(가장 최근 10개 -> 페이지 0)
             // 무한 스크롤 등을 구현하여, page 별로 요청하면 됨.
             const page = 0;
-            fetch(`http://localhost:8080/love/chat/${page}`)
+            fetch(`http://localhost:8080/chatting/love/${page}`)
                 .then(res => res.json())
                 .then(data => {
                     data.result.reverse().forEach((message) => {


### PR DESCRIPTION
### 수정 내역
**1, member API 에러 핸들링 코드 수정**
- 수정 전: 에러 발생 시 BaseResponse로 반환 -> 에러 메시지와 200 반환
- 수정 후: 에러 발생 시 BaseException 던짐 -> 에러 메시지와 지정한 http status 반환

예시 코드
``` java
// 수정 전
return new BaseResponse.ok(BaseResponseStatus.USER_ALREADY_EXIST_USERNAME);

// 수정 후
throw new BaseException(BaseResponseStatus.USER_ALREADY_EXIST_USERNAME);
```

</br>

**2. member API 반환 형식 통일**
- 수정 전: BaseResponse와 ResponseEntity 섞여있었음
- 수정 후: BaseResponse로 통일

</br>

**3. 채팅 내역 리스트 조회 URI 변경**
- 변경한 채팅방: 기숙사, 연애 상담, 라이브
- chatting prefix 추가
- /chat 경로 삭제
- 예시
  - 수정 전: /dorm/chat/{page}
  - 수정 후: /chatting/dorm/{page}

</br>

---

### 기타
- 이메일 인증 API 테스트 완료
- 현재 1대 1 채팅 domain과 DB 구조 맞지 않아 문제 발생
  - 문제되는 `visible` 필드 주석 처리
  - Hibernate ddl-auto 옵션 validate로 변경