### PR TITLE
Feature/#68 일대일 채팅 경로 체크 및 에러 핸들링코드 추가

### DIFF
--- a/src/main/java/com/app/univchat/base/BaseResponseStatus.java
+++ b/src/main/java/com/app/univchat/base/BaseResponseStatus.java
@@ -56,7 +56,10 @@ public enum  BaseResponseStatus {
     USER_FAILED_TO_WITHDRAWAL("2014", "회원 탈퇴에 실패하였습니다", 400),
 
 
-
+    /**
+     * 3000 : websocket 오류
+     */
+    UNSUPPORTED_SUBSCRIBE_URI("3001", "지원하지 않는 구독경로입니다.", 400),
 
 
     /**

--- a/src/main/java/com/app/univchat/chat/ChatSendInterceptor.java
+++ b/src/main/java/com/app/univchat/chat/ChatSendInterceptor.java
@@ -6,7 +6,10 @@ import com.app.univchat.base.BaseResponseStatus;
 import com.app.univchat.domain.Member;
 import com.app.univchat.dto.ChatReq;
 import com.app.univchat.jwt.JwtProvider;
+import com.app.univchat.repository.OTOChatRepository;
+import com.app.univchat.repository.OTOChatRoomRepository;
 import com.app.univchat.service.MemberService;
+import com.app.univchat.service.OTOChatService;
 import io.jsonwebtoken.MalformedJwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +27,7 @@ public class ChatSendInterceptor implements ChannelInterceptor {
 
     private final JwtProvider jwtProvider;
     private final MemberService memberService;
+    private final OTOChatRoomRepository otoChatRoomRepository;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -33,6 +37,13 @@ public class ChatSendInterceptor implements ChannelInterceptor {
         
         // header의 Authorization 값 저장
         String authorization = String.valueOf(headerAccessor.getNativeHeader("Authorization"));
+
+        // command가 SUBSCRIBE인 경우 구독경로 검사
+        if(StompCommand.SUBSCRIBE.equals(headerAccessor.getCommand())) {
+            System.out.println("headerAccessor = " + headerAccessor.getDestination());
+            checkSub(headerAccessor.getDestination());
+            return message;
+        }
 
         // command가 SEND(메세지 전송)가 아닌 경우, Jwt 검사를 하지 않음.
         if(!(StompCommand.SEND.equals(headerAccessor.getCommand()))) {
@@ -79,5 +90,30 @@ public class ChatSendInterceptor implements ChannelInterceptor {
         if (!member.getNickname().equals(email)) {
             throw new BaseException(BaseResponseStatus.JWT_AND_NICKNAME_DONT_MATCH);
         }
+    }
+
+    /**
+     * 구독 URI 체크
+     */
+    public void checkSub(String sub) {
+        String[] splitSub = sub.split("/");
+        Long roomId = null;
+
+        //일대일 채팅 구독일 경우 만들어진 채팅방인지 확인
+        if(splitSub[2].equals("oto")) {
+            // roomId 추출
+            try {
+                roomId = Long.valueOf(Integer.parseInt(splitSub[3]));
+
+            } catch (ArrayIndexOutOfBoundsException e) {
+                throw new BaseException(BaseResponseStatus.UNSUPPORTED_SUBSCRIBE_URI);
+            }
+
+            // roomId DB에 있는지 체크
+            otoChatRoomRepository.findByRoomId(roomId).orElseThrow(
+                    () -> new BaseException(BaseResponseStatus.UNSUPPORTED_SUBSCRIBE_URI)
+            );
+        }
+
     }
 }

--- a/src/main/java/com/app/univchat/dto/ChatReq.java
+++ b/src/main/java/com/app/univchat/dto/ChatReq.java
@@ -40,21 +40,11 @@ public class ChatReq {
     /*
         연애 상담 채팅 req
      */
-    @Builder
     @NoArgsConstructor
-    @AllArgsConstructor
     @Getter
     @Setter
     @ApiModel(value = "LoveChatReq - 채팅 메시지 전송 객체")
     public static class LoveChatReq extends ChatReq {
-
-        @ApiModelProperty(name = "송신자 닉네임", example = "닉네임1")
-        @NotNull
-        protected String memberNickname; // 송신자 식별자
-
-        @ApiModelProperty(name = "채팅 내용", example = "채팅내용~~~")
-        @NotNull
-        protected String messageContent;
 
         public LoveChat toEntity(Optional<Member> member, String messageSendingTime) throws Exception {
             return LoveChat.builder()
@@ -115,7 +105,7 @@ public class ChatReq {
             return OTOChatRoom.builder()
                     .sender(sender.orElseThrow(() -> new Exception("존재하지 않는 회원입니다.")))
                     .receive(receive.orElseThrow(() -> new Exception("존재하지 않는 회원입니다.")))
-                    .visible(0)
+//                    .visible(0)
                     .lastMessageId(null)
                     .build();
         }


### PR DESCRIPTION
- STOMP command가 `SUBSCRIBE`인 경우 경로 체크하는 로직 추가
- 일대일 채팅의 경우 `/sub/oto/{roomId}`로 가정하여 roomId 유무 확인 -> roomId 없으면 에러 반환 후 웹 소켓 연결 해제
- 없는 roomId로 요청 시 -> 에러  반환 후 웹 소켓 연결 해제