### PR TITLE
Feature/#125 문의 접수 API 개발

### DIFF
--- a/src/main/java/com/app/univchat/base/BaseResponseStatus.java
+++ b/src/main/java/com/app/univchat/base/BaseResponseStatus.java
@@ -59,6 +59,7 @@ public enum  BaseResponseStatus {
 
     USER_NO_EXIST_CHATTING_ROOM("2016", "해당 채팅방에 사용자가 포함되어 있지 않습니다,", 404),
 
+    USER_FAILED_TO_ACCEPT_INQUIRY("2017", "문의 접수에 실패했습니다.", 400),
 
     /**
      * 5000 : Chatting 오류

--- a/src/main/java/com/app/univchat/controller/InquiryController.java
+++ b/src/main/java/com/app/univchat/controller/InquiryController.java
@@ -1,0 +1,40 @@
+package com.app.univchat.controller;
+
+import com.app.univchat.base.BaseException;
+import com.app.univchat.base.BaseResponse;
+import com.app.univchat.base.BaseResponseStatus;
+import com.app.univchat.dto.InquiryDto;
+import com.app.univchat.service.EmailService;
+import com.app.univchat.service.InquiryService;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import javax.mail.MessagingException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/inquiry")
+@RequiredArgsConstructor
+@Tag(name = "inquiry", description = "문의 관련 API")
+public class InquiryController {
+
+    private final EmailService emailService;
+    private final InquiryService inquiryService;
+
+    @Tag(name = "inquiry")
+    @ApiOperation(value = "문의 접수 API", notes = "문의 사항을 저장하고 문의 접수 성공 시 사용자에게 안내 메일을 보냅니다.")
+    @PostMapping("/register")
+    public BaseResponse<String> acceptInquiry(@RequestBody InquiryDto inquiry) {
+
+        try {
+            emailService.sendInquirySuccessMail(inquiry.getReceiverEmail(), inquiry.getContent());
+            inquiryService.saveEmailAndInquiry(inquiry.getReceiverEmail(), inquiry.getContent());
+
+            return BaseResponse.ok(BaseResponseStatus.SUCCESS, "접수하신 문의를 성공적으로 등록되었습니다. 입력한 이메일의 메일함을 확인하세요.");
+        } catch (MessagingException e) {
+            throw new BaseException(BaseResponseStatus.USER_FAILED_TO_ACCEPT_INQUIRY);
+        }
+    }
+}

--- a/src/main/java/com/app/univchat/domain/Inquiry.java
+++ b/src/main/java/com/app/univchat/domain/Inquiry.java
@@ -1,0 +1,24 @@
+package com.app.univchat.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@Builder
+@ToString
+@Table(name = "inquiry")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Inquiry {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long inquiryId;
+
+    @Column(nullable = false)
+    public String receiverEmail;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    public String content;
+}

--- a/src/main/java/com/app/univchat/dto/InquiryDto.java
+++ b/src/main/java/com/app/univchat/dto/InquiryDto.java
@@ -1,0 +1,31 @@
+package com.app.univchat.dto;
+
+import com.app.univchat.domain.Inquiry;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value = "Inquiry DTO")
+public class InquiryDto {
+
+    @ApiModelProperty(name = "문의 답변 수신 이메일", example = "catchat@catholic.ac.kr")
+    public String receiverEmail;
+
+    @ApiModelProperty(name = "문의 접수 내용", example = "실수로 계정을 탈퇴했는데, 삭제한 아이디를 복구할 수 있는 방법이 있을까요?")
+    public String content;
+
+    public Inquiry toEntity(String email, String inquiry) {
+
+        return Inquiry.builder()
+                .receiverEmail(email)
+                .content(inquiry)
+                .build();
+    }
+}

--- a/src/main/java/com/app/univchat/repository/InquiryRepository.java
+++ b/src/main/java/com/app/univchat/repository/InquiryRepository.java
@@ -1,0 +1,7 @@
+package com.app.univchat.repository;
+
+import com.app.univchat.domain.Inquiry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+}

--- a/src/main/java/com/app/univchat/service/EmailService.java
+++ b/src/main/java/com/app/univchat/service/EmailService.java
@@ -2,6 +2,7 @@ package com.app.univchat.service;
 
 import com.app.univchat.dto.MemberRes;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
@@ -14,8 +15,10 @@ import java.util.Random;
 @RequiredArgsConstructor
 public class EmailService {
 
-    private final JavaMailSender emailSender;
+    @Value("${spring.mail.username}")
+    private String adminEmail;
 
+    private final JavaMailSender emailSender;
 
     //회원가입 시 메일 인증 코드
     public MemberRes.EmailAuthRes sendEmail(String email) throws MessagingException, UnsupportedEncodingException {
@@ -52,5 +55,27 @@ public class EmailService {
         return emailAuthRes;
     }
 
+    // 문의 접수 완료 메일 전송
+    public void sendInquirySuccessMail(String userEmail, String inquiry) throws MessagingException {
 
+        // 메일 제목 및 내용
+        String title = "[CatChat] 접수하신 문의가 성공적으로 등록되었습니다.";
+        String content = "";
+        content += "<div style='margin:10%; padding:20px; background-color:#f5f5f5;'>";
+        content += "<h2 style='color: #003091; text-align:center; padding: 10px;'>접수하신 문의가 성공적으로 등록되었습니다.</h2>";
+        content += "<div style='background-color: white; padding: 20px; border-radius: 10px;'>";
+        content += "<p style='font-size: 18px; color: #555;'>문의하신 내용은 아래와 같습니다.</p>";
+        content += "<pre style='background-color: #f9f9f9; padding: 10px; border-radius: 5px; color: #003091;'>" + inquiry + "</pre>";
+        content += "<p style='font-size: 18px; color: #555;'>빠른 시일 내 문의해주신 내용에 답변 메일을 보내드리겠습니다. 감사합니다.</p>";
+        content += "</div>";
+        content += "</div>";
+
+        // 메일 전송
+        MimeMessage message = emailSender.createMimeMessage();
+        message.setFrom(adminEmail);
+        message.addRecipients(MimeMessage.RecipientType.TO, userEmail);
+        message.setSubject(title);
+        message.setText(content, "utf-8", "html");
+        emailSender.send(message);
+    }
 }

--- a/src/main/java/com/app/univchat/service/InquiryService.java
+++ b/src/main/java/com/app/univchat/service/InquiryService.java
@@ -1,0 +1,18 @@
+package com.app.univchat.service;
+
+import com.app.univchat.domain.Inquiry;
+import com.app.univchat.dto.InquiryDto;
+import com.app.univchat.repository.InquiryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InquiryService {
+
+    private final InquiryRepository inquiryRepository;
+
+    public void saveEmailAndInquiry(String email, String inquiry) {
+        inquiryRepository.save(new InquiryDto().toEntity(email, inquiry));
+    }
+}


### PR DESCRIPTION
- 문의 접수 API를 구현하였습니다.
  - 해당 API 요청 시, 전달받은 수신자 이메일과 문의 내용을 DB에 저장합니다.
  - 문의 접수 성공 시 확인 메일을 보냅니다. 아래는 예시 확인 메일입니다.
<img width="1112" alt="exampleMail" src="https://github.com/UnivChat/app-server/assets/67030031/8fa902f9-efc2-47a8-91d1-944ce3d8bd8e">
