### PR TITLE
Feature/#122 탈퇴한 회원 채팅 내역 조회 수정 (live, love, dorm 채팅)

### DIFF
--- a/src/main/java/com/app/univchat/base/BaseResponseStatus.java
+++ b/src/main/java/com/app/univchat/base/BaseResponseStatus.java
@@ -60,6 +60,7 @@ public enum  BaseResponseStatus {
     USER_NO_EXIST_CHATTING_ROOM("2016", "해당 채팅방에 사용자가 포함되어 있지 않습니다,", 404),
 
     USER_FAILED_TO_ACCEPT_INQUIRY("2017", "문의 접수에 실패했습니다.", 400),
+    USER_IS_WITHDRAWAL("2018", "탈퇴한 회원입니다.", 400),
 
     /**
      * 5000 : Chatting 오류

--- a/src/main/java/com/app/univchat/chat/ChatSendInterceptor.java
+++ b/src/main/java/com/app/univchat/chat/ChatSendInterceptor.java
@@ -67,7 +67,25 @@ public class ChatSendInterceptor implements ChannelInterceptor {
         // 닉네임 DB에 있는지 체크 & jwt와 일치하는지 확인
 //        checkNickname(message, email);
 
+        // jwt에서 추출한 email DB에 있는지 확인 & 탈퇴한 회원인지 확인
+        checkMember(email);
+
         return message;
+    }
+
+    /**
+     * email DB에 있는지 확인 & 탈퇴한 회원인지 확인
+     */
+    public void checkMember(String email) {
+        //DB 조회
+        Member member = memberService.getMemberByEmail(email).orElseThrow(
+                () -> new BaseException(BaseResponseStatus.USER_NOT_EXIST_ERROR
+                ));
+
+        //탈퇴 여부 확인
+        if (member.isWithdrawal()) {
+            throw new BaseException(BaseResponseStatus.USER_IS_WITHDRAWAL);
+        }
     }
 
     /**

--- a/src/main/java/com/app/univchat/controller/chat/DormChatController.java
+++ b/src/main/java/com/app/univchat/controller/chat/DormChatController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,12 +34,13 @@ public class DormChatController {
     @Tag(name = "chatting-dorm")
     @MessageMapping("/dorm")
     @SendTo("/sub/dorm")
-    public ChatRes.DormChatRes sendToDormChattingRoom(ChatReq.DormChatReq dormChatReq) {
+    public ChatRes.DormChatRes sendToDormChattingRoom(ChatReq.DormChatReq dormChatReq,
+                                                      SimpMessageHeaderAccessor accessor) {
 
         String messageSendingTime = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:SSS").format(new Date());
         String plainMessageContent = dormChatReq.getMessageContent();
-
-        dormChatService.saveChat(dormChatReq, messageSendingTime);
+        String authorization = String.valueOf(accessor.getNativeHeader("Authorization"));
+        dormChatService.saveChat(dormChatReq, messageSendingTime, authorization);
 
         return new ChatRes.DormChatRes().builder()
                 .memberNickname(dormChatReq.getMemberNickname())

--- a/src/main/java/com/app/univchat/controller/chat/LiveChatController.java
+++ b/src/main/java/com/app/univchat/controller/chat/LiveChatController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,10 +33,13 @@ public class LiveChatController {
     @Tag(name = "chatting-live")
     @MessageMapping("/live")
     @SendTo("/sub/live")
-    public ChatRes.LiveChatRes sendToDormChattingRoom(ChatReq.LiveChatReq liveChatReq) {
+    public ChatRes.LiveChatRes sendToLiveChattingRoom(ChatReq.LiveChatReq liveChatReq,
+                                                      SimpMessageHeaderAccessor accessor) {
         String messageSendingTime = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:SSS").format(new Date());
         String plainMessageContent = liveChatReq.getMessageContent();
-        liveChatService.saveChat(liveChatReq, messageSendingTime); //채팅 내역 저장
+        String authorization = String.valueOf(accessor.getNativeHeader("Authorization"));
+        liveChatService.saveChat(liveChatReq, messageSendingTime, authorization); //채팅 내역 저장
+
 
         return new ChatRes.LiveChatRes().builder()
                 .memberNickname(liveChatReq.getMemberNickname())

--- a/src/main/java/com/app/univchat/controller/chat/LoveChatController.java
+++ b/src/main/java/com/app/univchat/controller/chat/LoveChatController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,12 +33,13 @@ public class LoveChatController {
     @Tag(name = "chatting-love")
     @MessageMapping("/love")
     @SendTo("/sub/love")
-    public ChatRes.LoveChatRes sendToLoveChattingRoom(ChatReq.LoveChatReq loveChatReq) {
+    public ChatRes.LoveChatRes sendToLoveChattingRoom(ChatReq.LoveChatReq loveChatReq,
+                                                      SimpMessageHeaderAccessor accessor) {
 
         String messageSendingTime = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:SSS").format(new Date());
         String plainMessageContent = loveChatReq.getMessageContent();
-
-        loveChatService.saveChat(loveChatReq, messageSendingTime);
+        String authorization = String.valueOf(accessor.getNativeHeader("Authorization"));
+        loveChatService.saveChat(loveChatReq, messageSendingTime, authorization);
 
         return new ChatRes.LoveChatRes().builder()
                 .memberNickname(loveChatReq.getMemberNickname())

--- a/src/main/java/com/app/univchat/domain/Member.java
+++ b/src/main/java/com/app/univchat/domain/Member.java
@@ -48,7 +48,7 @@ public class Member {
     }
 
     public void deleteMember() {
-        this.nickname = "탈퇴한 회원";
+//        this.nickname = "탈퇴한 회원";
         this.gender = "none";
 
         this.isWithdrawal = true;

--- a/src/main/java/com/app/univchat/dto/ChatReq.java
+++ b/src/main/java/com/app/univchat/dto/ChatReq.java
@@ -31,9 +31,9 @@ public class ChatReq {
     @ApiModel(value = "DormChatReq - 채팅 메시지 전송 객체")
     public static class DormChatReq extends ChatReq {
 
-        public DormChat toEntity(Optional<Member> member, String messageSendingTime) throws Exception {
+        public DormChat toEntity(Member member, String messageSendingTime) throws Exception {
             return DormChat.builder()
-                    .member(member.orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_EXIST_ERROR)))
+                    .member(member)
                     .messageContent(messageContent)
                     .messageSendingTime(messageSendingTime)
                     .build();
@@ -50,9 +50,9 @@ public class ChatReq {
     @ApiModel(value = "LoveChatReq - 채팅 메시지 전송 객체")
     public static class LoveChatReq extends ChatReq {
 
-        public LoveChat toEntity(Optional<Member> member, String messageSendingTime) throws Exception {
+        public LoveChat toEntity(Member member, String messageSendingTime) throws Exception {
             return LoveChat.builder()
-                    .member(member.orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_EXIST_ERROR)))
+                    .member(member)
                     .messageContent(messageContent)
                     .messageSendingTime(messageSendingTime)
                     .build();

--- a/src/main/java/com/app/univchat/dto/ChatRes.java
+++ b/src/main/java/com/app/univchat/dto/ChatRes.java
@@ -1,5 +1,8 @@
 package com.app.univchat.dto;
 
+import com.app.univchat.domain.DormChat;
+import com.app.univchat.domain.LiveChat;
+import com.app.univchat.domain.LoveChat;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.List;
@@ -14,6 +17,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 public class ChatRes {
 
+    protected String memberEmail;
     protected String memberNickname;
     protected String messageContent;
     protected String messageSendingTime;
@@ -23,7 +27,14 @@ public class ChatRes {
     @Setter
     @Getter
     // 기숙사 채팅 메시지 객체
-    public static class DormChatRes extends ChatRes { }
+    public static class DormChatRes extends ChatRes {
+        public DormChatRes(DormChat chat) {
+            memberEmail = chat.getMember().getEmail();
+            memberNickname = chat.getMember().isWithdrawal() ? "탈퇴한 회원" : chat.member.getNickname();
+            messageContent = chat.getMessageContent();
+            messageSendingTime = chat.getMessageSendingTime();
+        }
+    }
 
     @Builder
     @NoArgsConstructor
@@ -42,7 +53,14 @@ public class ChatRes {
     @Setter
     @Getter
     // 연애상담 채팅 메시지 객체
-    public static class LoveChatRes extends ChatRes { }
+    public static class LoveChatRes extends ChatRes {
+        public LoveChatRes(LoveChat chat) {
+            memberEmail = chat.getMember().getEmail();
+            memberNickname = chat.getMember().isWithdrawal() ? "탈퇴한 회원" : chat.member.getNickname();
+            messageContent = chat.getMessageContent();
+            messageSendingTime = chat.getMessageSendingTime();
+        }
+    }
 
     @Builder
     @NoArgsConstructor
@@ -63,7 +81,14 @@ public class ChatRes {
     @Setter
     @Getter
     // 라이브 채팅 메시지 객체
-    public static class LiveChatRes extends ChatRes { }
+    public static class LiveChatRes extends ChatRes {
+        public LiveChatRes(LiveChat chat) {
+            memberEmail = chat.getMember().getEmail();
+            memberNickname = chat.getMember().isWithdrawal() ? "탈퇴한 회원" : chat.member.getNickname();
+            messageContent = chat.getMessageContent();
+            messageSendingTime = chat.getMessageSendingTime();
+        }
+    }
 
     @Builder
     @NoArgsConstructor

--- a/src/main/java/com/app/univchat/service/CipherService.java
+++ b/src/main/java/com/app/univchat/service/CipherService.java
@@ -2,6 +2,7 @@ package com.app.univchat.service;
 
 import com.app.univchat.base.BaseException;
 import com.app.univchat.base.BaseResponseStatus;
+import com.app.univchat.domain.Member;
 import com.app.univchat.dto.ChatReq;
 import com.app.univchat.dto.ChatRes;
 import com.app.univchat.dto.ClassChatReq;
@@ -29,13 +30,13 @@ public class CipherService {
     private String CIPHER_MODE;
     private final byte[] IV = new byte[16];
 
-    public ChatReq encryptChat(ChatReq chat) {
+    public ChatReq encryptChat(ChatReq chat, Member member) {
 
         try {
 
         // 비밀키 생성
         MessageDigest secret = MessageDigest.getInstance(HASH_TYPE);
-        byte[] secretDigest = secret.digest((HASH_SEED + chat.getMemberNickname()).getBytes(StandardCharsets.UTF_8));
+        byte[] secretDigest = secret.digest((HASH_SEED + member.getEmail()).getBytes(StandardCharsets.UTF_8));
 
         // 암호화 준비
         SecretKeySpec keySpec = new SecretKeySpec(secretDigest, CIPHER_TYPE);
@@ -91,7 +92,7 @@ public class CipherService {
 
         // 비밀키 생성
         MessageDigest secret = MessageDigest.getInstance(HASH_TYPE);
-        byte[] secretDigest = secret.digest((HASH_SEED + chat.getMemberNickname()).getBytes(StandardCharsets.UTF_8));
+        byte[] secretDigest = secret.digest((HASH_SEED + chat.getMemberEmail()).getBytes(StandardCharsets.UTF_8));
 
         // base64 디코딩
         byte[] decodedCipherChat = Base64.getDecoder().decode(chat.getMessageContent().getBytes("UTF-8"));

--- a/src/main/java/com/app/univchat/service/MemberService.java
+++ b/src/main/java/com/app/univchat/service/MemberService.java
@@ -103,6 +103,13 @@ public class MemberService {
     }
 
     /**
+     * email을 통한 member 조회
+     */
+    public Optional<Member> getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email);
+    }
+
+    /**
      * 성별 조회
      */
     public MemberRes.GenderRes viewGender(Member member) throws IOException{

--- a/src/main/java/com/app/univchat/service/chat/LiveChatService.java
+++ b/src/main/java/com/app/univchat/service/chat/LiveChatService.java
@@ -51,7 +51,7 @@ public class LiveChatService {
         );
 
         // 채팅 내역 저장
-        liveChatRepository.save(((ChatReq.LiveChatReq)(cipherService.encryptChat(liveChatReq))).toEntity(sender, messageSendTime));
+        liveChatRepository.save(((ChatReq.LiveChatReq)(cipherService.encryptChat(liveChatReq, sender))).toEntity(sender, messageSendTime));
     }
 
     /**
@@ -93,7 +93,8 @@ public class LiveChatService {
             page1 = Stream.concat(page1.stream(), page2.stream()).collect(Collectors.toList());
         }
         List<ChatRes.LiveChatRes> chattingList = page1.stream()
-                .map(chat -> modelMapper.map(chat, ChatRes.LiveChatRes.class))
+//                .map(chat -> modelMapper.map(chat, ChatRes.LiveChatRes.class))
+                .map(ChatRes.LiveChatRes::new)
                 .peek(chat -> chat.setMessageContent(cipherService.decryptChat(chat).getMessageContent())) //채팅 복호화
                 .sorted((o1, o2) -> o2.getMessageSendingTime().compareTo(o1.getMessageSendingTime())) //채팅 보낸 시간으로 정렬
                 .collect(Collectors.toList());

--- a/src/main/java/com/app/univchat/service/chat/OTOChatService.java
+++ b/src/main/java/com/app/univchat/service/chat/OTOChatService.java
@@ -96,7 +96,7 @@ public class OTOChatService {
         Optional<OTOChatRoom> room = otoChatRoomRepository.findByRoomId(roomId);
 
         // 채팅 내역 저장
-        otoChatRepository.save(((ChatReq.OTOChatReq)cipherService.encryptChat(otoChatReq)).toEntity(room, sender ,messageSendingTime));
+        otoChatRepository.save(((ChatReq.OTOChatReq)cipherService.encryptChat(otoChatReq, sender.get())).toEntity(room, sender ,messageSendingTime));
 
     }
 


### PR DESCRIPTION
### 수정 내역
**탈퇴방식**
- 닉네임 "탈퇴한 회원"으로 수정 -> 닉네임 수정 x
</br>

**채팅 전송**
- 닉네임으로 member 조회 -> jwt에서 email 추출하여 memebr 조회
</br>

**채팅 암/복호화**
- key값 생성 시 닉네임 사용 -> email 사용하도록 수정 (클래스 채팅 암/복호화는 수정 x)
- 이를 반영할 경우 이전 채팅 기록 삭제해야 함
  - 이전 채팅에는 닉네임으로 암호화 했기 때문
</br>

**탈퇴한 회원 채팅 조회**
- 탈퇴한 회원은 닉네임 "탈퇴한 회원"으로 수정
  - ChatRes dto로 매핑 시 modelMapper에서 생성자 모델 사용하여 탈퇴한 회원인지 체크

</br>